### PR TITLE
Reorder drivers according to active

### DIFF
--- a/velafrica/transport/models.py
+++ b/velafrica/transport/models.py
@@ -43,7 +43,7 @@ class Driver(models.Model):
         return u"{}".format(self.name)
 
     class Meta:
-        ordering = ['name']
+        ordering = ['-active', 'name']
 
 
 class VeloState(models.Model):


### PR DESCRIPTION
Reorders the driver dropdown for rides such that active drivers are top of the list.