### PR TITLE
Speed up bike pdf rendering

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -75,6 +75,7 @@ URLObject = "*"
 YURL = "*"
 openpyxl = "!= 3.0.2"
 weasyprint = "*"
+reportlab = "*"
 
 
 [requires]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -815,6 +815,40 @@
             ],
             "version": "==5.3"
         },
+        "reportlab": {
+            "hashes": [
+                "sha256:2a1c4ea2155fd5b6e3f89e36b8aa21b5a14c9bbaf9b44de2787641668bc95edc",
+                "sha256:2b7469a98df1315d4f52319c4438eaee3fdd17330830edadae775e9312402638",
+                "sha256:3b556160aac294fa661545245e4bc273328f9226e5110139647f4d4bc0cfc453",
+                "sha256:3eb25d2c2bde078815d8f7ea400abbcae16a0c498a4b27ead3c4a620b1f1f980",
+                "sha256:3f229c0b2ca27eb5b08777981d3bd0d34e59bfa306627b88d80c3734cd3e26d5",
+                "sha256:4695755cc70b7a9308508aa41eafc3f335348be0eadd86e8f92cb87815d6177b",
+                "sha256:4f97b4474e419ae5c441ecdf0db8eceb5f5af0461bdf73e3e5ec05353844045c",
+                "sha256:550d2d8516e468192e12be8aeaf80f3bd805dc46dd0a5a4ddf2a3e1cd8149a16",
+                "sha256:59aa9c4ca80d397f6cabec092b5a6e2304fb1b7ca53e5b650872aae13ebfeb68",
+                "sha256:6e4479b75778b9c1e4640dc90efb72cb990471d56089947d6be4ccd9e7a56a3c",
+                "sha256:6e9434bd0afa6d6fcf9abbc565750cc456b6e60dc49abd7cd2bc7cf414ee079b",
+                "sha256:73e4e30b72da1f9f8caba775ad9cc027957c2340c38ba2d6622a9f2351b12c3a",
+                "sha256:7c05c2ba8ab32f02b23a56a75a4d136c2bfb7221a04a8306835a938fa6711644",
+                "sha256:849e4cabce1ed1183e83dc89570810b3bf9bf9cf0d0a605bde854a0baf212124",
+                "sha256:863c6fcf5fc0c8184b6315885429f5468373a3def2eb0c0073d09b79b2161113",
+                "sha256:8e688df260682038ecd32f106d796024fbcf70e7bf54340b14f991bd5465f97a",
+                "sha256:9675a26d01ec141cb717091bb139b6227bfb3794f521943101da50327bff4825",
+                "sha256:969b0d9663c0c641347d2408d41e6723e84d9f7863babc94438c91295c74f36d",
+                "sha256:978560732758bf5fca4ec1ed124afe2702d08824f6b0364cca31519bd5e7dadd",
+                "sha256:99ea85b47248c6cdbece147bdbd67aed16209bdd95770aa1f151ec3bb8794496",
+                "sha256:9cdc318c37fa959909db5beb05ca0b684d3e2cba8f40af1ce6f332c3f69bd2b8",
+                "sha256:b55c26510ff7f135af8eae1216372028cde7dab22003d918649fce219020eb58",
+                "sha256:cb301340b4fc1f2b7b25ea4584c5cbde139ced2d4ff01ad5e8fcf7d7822982b0",
+                "sha256:e7578a573454a5490553fb091374996d32269dff44021a401763080bda1357cf",
+                "sha256:e84387d35a666aafafda332afca8a75fb04f097cc0a2dc2d04e8c90a83cf7c1b",
+                "sha256:eb66eff64ea75f028af3ac63a7a2bf1e8733297141a85cbdffd5deaef404fa52",
+                "sha256:f5e3afd2cc35a73f34c3084c69fe4653591611da5189e50b58db550bb46e340a",
+                "sha256:f6c10628386bfe0c1f6640c28fb262d0960bb26c249cefabb755fb273323220d"
+            ],
+            "index": "pypi",
+            "version": "==3.5.34"
+        },
         "requests": {
             "hashes": [
                 "sha256:11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4",

--- a/velafrica/bikes/render_pdf.py
+++ b/velafrica/bikes/render_pdf.py
@@ -1,0 +1,92 @@
+import io
+import os
+
+from reportlab.lib.pagesizes import landscape, A4
+from reportlab.lib.utils import simpleSplit
+from reportlab.pdfgen.canvas import Canvas
+
+from velafrica.core.settings import PROJECT_DIR
+
+
+# PDF-PLOT
+
+def pdf_page_frame(canvas, logo=None):
+    if logo:
+        canvas.drawImage(logo, x=657.5, y=471, width=164.4, preserveAspectRatio=True)
+
+    # End Page
+    canvas.showPage()
+
+
+def draw_pdf_page(canvas, table=[], extraordinary=None, title=None, image=None, logo=None, fontsize=12):
+    # Header - Title and Logo
+    if title:
+        canvas.setFont("Helvetica", 32)
+        canvas.drawString(x=40, y=510, text=title)
+
+    # Content
+    canvas.setFont("Helvetica", fontsize)
+
+    # Table
+    y = 450 - fontsize  # origin of coordinates is bottom left
+    for (label, value) in table:
+        canvas.drawString(40, y, label)
+
+        # breaks lines if too long and then draw line by line
+        for line in simpleSplit(text=value, fontName=canvas._fontname, fontSize=canvas._fontsize, maxWidth=130):
+            canvas.drawString(175, y, line)
+            y -= 15
+        y -= 6  # add spacing between two rows
+
+    if extraordinary:
+        canvas.drawString(40, y, "Extraordinary:")
+        y -= 16
+        for line in simpleSplit(text=extraordinary, fontName=canvas._fontname, fontSize=canvas._fontsize, maxWidth=255):
+            canvas.drawString(50, y, line)
+            y -= 15
+
+    # plot image
+    if image:
+        try:
+            w = 480
+            h = image.height / image.width * w  # keep ratio
+            canvas.drawImage(image.url, x=321.9, y=450 - h, width=w, height=h)
+        except IOError:
+            print("Image not found");
+
+    pdf_page_frame(canvas, logo)
+
+
+def render_bikes_to_pdf_with_reportlab(queryset, fields={}, title=None, subtitle=None):
+    buf = io.BytesIO()
+    canvas = Canvas(buf, pagesize=landscape(A4))  # W, H = landscape(A4)  # 841.9, 595.27
+
+    logo = os.path.join(PROJECT_DIR, 'frontend', 'static', 'img/velafrica_RGB.jpg')
+
+    # title page
+    canvas.setFont("Helvetica", 28)
+    canvas.drawCentredString(text=title, x=841.9/2, y=300)
+    canvas.setFont("Helvetica", 20)
+    canvas.drawCentredString(text=subtitle, x=841.9/2, y=270)
+    pdf_page_frame(canvas, logo)
+
+    # bike pages
+    for bike in queryset:
+        draw_pdf_page(
+            canvas=canvas,
+            table=[
+                (label, "{}".format(bike.__getattribute__(key)))
+                for key, label in fields.items()
+                if bike.__getattribute__(key)  # if not blank
+            ],
+            extraordinary=bike.extraordinary,
+            image=bike.image,
+            logo=logo,
+            title="A+ Bike"
+        )
+
+    # Close the PDF object cleanly
+    canvas.save()
+    buf.seek(0)
+
+    return buf.getvalue()

--- a/velafrica/bikes/render_pdf.py
+++ b/velafrica/bikes/render_pdf.py
@@ -66,15 +66,17 @@ def render_bikes_to_pdf_with_reportlab(queryset, fields={}, title=None, subtitle
     # title page
     canvas.setFont("Helvetica", 28)
     canvas.drawCentredString(text=title, x=841.9/2, y=300)
+
     canvas.setFont("Helvetica", 20)
     canvas.drawCentredString(text=subtitle, x=841.9/2, y=270)
+    
     pdf_page_frame(canvas, logo)
 
     # bike pages
     for bike in queryset:
         draw_pdf_page(
             canvas=canvas,
-            table=[
+            table=[  # label - value pairs for selected 'fields'
                 (label, "{}".format(bike.__getattribute__(key)))
                 for key, label in fields.items()
                 if bike.__getattribute__(key)  # if not blank

--- a/velafrica/bikes/render_pdf.py
+++ b/velafrica/bikes/render_pdf.py
@@ -12,7 +12,7 @@ from velafrica.core.settings import PROJECT_DIR
 
 def pdf_page_frame(canvas, logo=None):
     if logo:
-        canvas.drawImage(logo, x=657.5, y=471, width=164.4, preserveAspectRatio=True)
+        canvas.drawImage(logo, x=657.5, y=471, width=2466 / 15, height=1565 / 15)
 
     # End Page
     canvas.showPage()

--- a/velafrica/bikes/views.py
+++ b/velafrica/bikes/views.py
@@ -4,22 +4,31 @@ from dal import autocomplete
 from django.views.generic import ListView
 
 from velafrica.bikes.models import Bike, BikeCategory
-from velafrica.core.pdf_utils import render_to_pdf
+from velafrica.bikes.render_pdf import render_bikes_to_pdf_with_reportlab
+from velafrica.core.pdf_utils import make_response
 
 
 def bikes_pdf(request, queryset, title=None, subtitle=None, filename=""):
-    return render_to_pdf(
-        request,
-        template="bikes/bikes_pdf.html",
-        context={
-            "title": title,
-            "subtitle": subtitle,
-            "pagesize": "A4 landscape",
-            "logo": 'img/velafrica_RGB.jpg',
-            "stylesheets": ("css/bike_plot.css",),
-            "bikes": queryset,
-        },
-        filename="{}.pdf".format(filename) if filename else None,
+    return make_response(
+        render_bikes_to_pdf_with_reportlab(
+            queryset,
+            fields={
+                "number": "No.",
+                "category": "Type",
+                "brand": "Brand",
+                "bike_model": "Model",
+                "gearing": "Group of components",
+                "drivetrain": "Drivetrain",
+                "brake": "Brake",
+                "colour": "Colour",
+                "size": "Size",
+                "suspension": "Suspension",
+                "rear_suspension": "Rear suspension"
+            },
+            title=title,
+            subtitle=subtitle
+        ),
+        filename="{}.pdf".format(filename) if filename else None
     )
 
 


### PR DESCRIPTION
workaround for #37 

Back to reportlab which is way faster. Uses the same `bikes_pdf()` function.