### PR TITLE
Bike status

### DIFF
--- a/velafrica/bikes/admin.py
+++ b/velafrica/bikes/admin.py
@@ -106,7 +106,7 @@ class BikeAdmin(ImportExportMixin, admin.ModelAdmin):
 
     # "for_sale" a boolean column in the list-view
     def for_sale(self, obj):
-        return obj.container is None
+        return obj.container is None and obj.status is 0
 
     for_sale.short_description = "For sale"
     for_sale.admin_order_field = 'container'

--- a/velafrica/bikes/admin.py
+++ b/velafrica/bikes/admin.py
@@ -10,7 +10,7 @@ from import_export import resources
 from import_export.admin import ImportExportMixin
 
 from velafrica.bikes.forms import BikeForm
-from velafrica.bikes.models import Bike, BikeCategory
+from velafrica.bikes.models import Bike, BikeCategory, BikeStatus
 from velafrica.bikes.views import bikes_pdf
 from velafrica.transport.filter import MultiListFilter
 
@@ -42,7 +42,7 @@ class APlusFilter(MultiListFilter):
                 query=Q(
                     container__isnull=False,  # not yet sold and shipped within another container
                     a_plus__exact=True,  # is A+
-                    status__exact=0  # status 'normal'
+                    status__exact=BikeStatus.NORMAL
                 )
             ),
             MultiListFilter.Option(
@@ -51,7 +51,7 @@ class APlusFilter(MultiListFilter):
                 query=Q(
                     container__isnull=True,  # not yet sold and shipped within another container
                     a_plus__exact=True,  # is A+
-                    status__exact=0  # status 'normal'
+                    status__exact=BikeStatus.NORMAL
                 )
             )
         ]
@@ -62,7 +62,7 @@ def plot_bikes_for_sale(request):
         request=request,
         queryset=Bike.objects.filter(
             container__isnull=True,  # not sold
-            status__exact=0,  # status = 'normal'
+            status__exact=BikeStatus.NORMAL,
         ).order_by("number"),
         title='A+ bikes for sale',
         subtitle="{:%d.%m.%Y}".format(datetime.today()),
@@ -100,13 +100,14 @@ class BikeAdmin(ImportExportMixin, admin.ModelAdmin):
         APlusFilter,
         'category',
         ('date', DateRangeFilter),
+        'status',
         'container',
         'warehouse',
     ]
 
     # "for_sale" a boolean column in the list-view
     def for_sale(self, obj):
-        return obj.container is None and obj.status is 0
+        return obj.container is None and obj.status is BikeStatus.NORMAL
 
     for_sale.short_description = "For sale"
     for_sale.admin_order_field = 'container'

--- a/velafrica/bikes/admin.py
+++ b/velafrica/bikes/admin.py
@@ -161,6 +161,12 @@ class BikeAdmin(ImportExportMixin, admin.ModelAdmin):
              'fields': ('container',)
          }
          ),
+        ('Extra',
+         {
+             'fields': ('status',),
+             'classes': ('collapse',),
+         }
+         )
     )
 
     def container_list_item(self, obj):

--- a/velafrica/bikes/models.py
+++ b/velafrica/bikes/models.py
@@ -48,6 +48,11 @@ class BikeCategory(models.Model):
         verbose_name_plural = "bike categories"
 
 
+class BikeStatus:
+    NORMAL = 0
+    DISMISSED = 1
+
+
 class Bike(models.Model):
     id = models.CharField(primary_key=True, unique=True, default=bike_id, max_length=255)
 

--- a/velafrica/bikes/models.py
+++ b/velafrica/bikes/models.py
@@ -88,11 +88,15 @@ class Bike(models.Model):
     suspension = models.CharField(max_length=255, null=True, blank=True, verbose_name=u"Suspension")
     rear_suspension = models.CharField(max_length=255, null=True, blank=True, verbose_name=u"Rear Suspension")
     extraordinary = models.TextField(max_length=255, null=True, blank=True, verbose_name=u"Extraordinary")
-    status = models.IntegerField(default=0, verbose_name='status',
-                                 choices=[
-                                     {0, 'Normal'},
-                                     {1, 'Dismissed'}
-                                 ])
+    status = models.IntegerField(
+        default=0,
+        verbose_name='status',
+        choices=[
+            (0, 'Normal'),
+            (1, 'Dismissed'),
+        ],
+        help_text="Dismissed = bike is neither in stock nor sold."
+    )
 
     # image(s)
     image = ResizedImageField(

--- a/velafrica/bikes/models.py
+++ b/velafrica/bikes/models.py
@@ -97,8 +97,8 @@ class Bike(models.Model):
         default=0,
         verbose_name='status',
         choices=[
-            (0, 'Normal'),
-            (1, 'Dismissed'),
+            (BikeStatus.NORMAL, 'Normal'),
+            (BikeStatus.DISMISSED, 'Dismissed'),
         ],
         help_text="Dismissed = bike is neither in stock nor sold."
     )


### PR DESCRIPTION
As said in #56 bike.status was not well implemented.

The `for_sale` column newly takes the bike.status into account. 
Bike.status is added to the bikes change view, so it can be set, if needed.  

Fixes #56